### PR TITLE
Removed const_if_match feature gate. Stabilized in Rust 1.45

### DIFF
--- a/zenoh-util/src/lib.rs
+++ b/zenoh-util/src/lib.rs
@@ -11,8 +11,6 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-#![feature(const_if_match)]
-
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
See https://github.com/eclipse-zenoh/zenoh/issues/18